### PR TITLE
Follow 301 Redirects

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -24,7 +24,7 @@ get_download_url() {
   local version="$1"
   local platform="$2"
 
-  echo "https://github.com/heptio/authenticator/releases/download/v${version}/heptio-authenticator-aws_${version}_${platform}"
+  echo "https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v${version}/aws-iam-authenticator_${version}_${platform}"
 }
 
 install $ASDF_INSTALL_TYPE $ASDF_INSTALL_VERSION $ASDF_INSTALL_PATH

--- a/bin/list-all
+++ b/bin/list-all
@@ -4,7 +4,7 @@ set -e
 set -o pipefail
 
 releases_path=https://api.github.com/repos/heptio/authenticator/releases
-cmd="curl -s"
+cmd="curl -sL"
 if [ -n "$GITHUB_API_TOKEN" ]; then
   cmd="$cmd -H 'Authorization: token $GITHUB_API_TOKEN'"
 fi

--- a/bin/list-all
+++ b/bin/list-all
@@ -17,5 +17,5 @@ function sort_versions() {
 }
 
 # Fetch all tag names, and get only second column. Then remove all unnecesary characters.
-versions=$(eval $cmd | grep -oE "tag_name\":\s*\".{1,15}\"," | sed 's/tag_name\": *\"v//;s/\",//' | sort_versions)
+versions=$(eval $cmd | grep -oE "tag_name\":\s*\".{1,15}\"," | sed 's/tag_name\": *\"v*//;s/\",//' | sort_versions)
 echo $versions


### PR DESCRIPTION
I'm getting a 301 from the current "releases_path=https://api.github.com/repos/heptio/authenticator/releases" so "asdf list-all heptio-authenticator-aws" comes back without any versions.

Adding in the -L to the curl command will follow this 301 and grab the current versions.

From the curl man page:
-L, --location
(HTTP) If the server reports that the requested page has moved to a different location  (indicated  with  a  Location: header  and  a 3XX response code), this option will make curl redo the request on the new place.


Current response:
`< HTTP/1.1 301 Moved Permanently
< Server: GitHub.com
< Date: Tue, 06 Aug 2019 23:32:23 GMT
< Content-Type: application/json; charset=utf-8
< Content-Length: 177
< Status: 301 Moved Permanently
< X-RateLimit-Limit: 60
< X-RateLimit-Remaining: 50
< X-RateLimit-Reset: 1565137943
< Location: https://api.github.com/repositories/99036030/releases
< X-GitHub-Media-Type: github.v3; format=json
< Access-Control-Expose-Headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
< Access-Control-Allow-Origin: *
< Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
< X-Frame-Options: deny
< X-Content-Type-Options: nosniff
< X-XSS-Protection: 1; mode=block
< Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
< Content-Security-Policy: default-src 'none'
< X-GitHub-Request-Id: A7BD:01E4:F01A3:24B2E3:5D4A0E07
< 
{
  "message": "Moved Permanently",
  "url": "https://api.github.com/repositories/99036030/releases",
  "documentation_url": "https://developer.github.com/v3/#http-redirects"
}
* Connection #0 to host api.github.com left intact
`

with this update:
`
./list-all
0.1.0 0.3.0 0.4.0 "0.4.0.alpha.1.z "0.4.0.alpha.3.z
`
